### PR TITLE
Add GitHub Actions workflow to deploy Sphinx docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. Do not cancel in-progress runs as we want
+# to allow these deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[docs]"
+
+      - name: Build Sphinx documentation
+        run: |
+          cd docs
+          make html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ all_templates = reg.list_all()
 ## Documentation
 
 Full documentation including a tutorial, user guide, and API reference is
-available at [memeplotlib.readthedocs.io](https://memeplotlib.readthedocs.io).
+available at [brianckeegan.github.io/memeplotlib](https://brianckeegan.github.io/memeplotlib/).
 
 To build the docs locally:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/brianckeegan/memeplotlib"
-Documentation = "https://memeplotlib.readthedocs.io"
+Documentation = "https://brianckeegan.github.io/memeplotlib/"
 Repository = "https://github.com/brianckeegan/memeplotlib"
 Issues = "https://github.com/brianckeegan/memeplotlib/issues"
 


### PR DESCRIPTION
- Create .github/workflows/docs.yml that builds Sphinx docs and deploys to GitHub Pages on pushes to main (and manual dispatch)
- Uses actions/upload-pages-artifact and actions/deploy-pages for the modern GitHub Pages deployment approach
- Update documentation URLs in README.md and pyproject.toml to point to brianckeegan.github.io/memeplotlib/

https://claude.ai/code/session_01HqzGB8zYrEQosJG4zLmLto