### PR TITLE
Add configurable base font size for auto-sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ import memeplotlib as memes
 
 memes.config.font = "comic"
 memes.config.color = "yellow"
+memes.config.fontsize = 120  # base font size in points
 memes.config.style = "none"  # don't auto-uppercase
 
 memes.meme("buzz", "custom defaults", "applied everywhere", show=False)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -86,6 +86,22 @@ Available ``font`` shortcuts: ``"impact"``, ``"arial"``, ``"comic"``,
 ``"times"``, ``"courier"``. You can also pass any font family name installed
 on your system.
 
+Font Size
+~~~~~~~~~~
+
+Use ``fontsize`` to set the text size in points. When omitted, font size is
+auto-calculated from the default base size (``config.fontsize``, 72 pt):
+
+.. code-block:: python
+
+   memes.meme("buzz", "big text", fontsize=120, show=False)
+
+You can also change the default base size globally:
+
+.. code-block:: python
+
+   memes.config.fontsize = 120
+
 Controlling Outline
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -172,6 +172,10 @@ All configurable attributes:
    * - ``outline_width``
      - ``2.0``
      - Outline stroke width.
+   * - ``fontsize``
+     - ``72.0``
+     - Base font size in points for auto-sizing. Explicit ``fontsize``
+       keyword arguments override this.
    * - ``dpi``
      - ``150``
      - Dots per inch for figure rendering.

--- a/examples/plot_configuration.py
+++ b/examples/plot_configuration.py
@@ -17,6 +17,7 @@ import memeplotlib as memes
 
 memes.config.font = "comic"
 memes.config.color = "yellow"
+memes.config.fontsize = 120
 memes.config.style = "none"
 
 memes.meme("buzz", "custom defaults", "applied everywhere", show=False)
@@ -26,4 +27,5 @@ memes.meme("buzz", "custom defaults", "applied everywhere", show=False)
 
 memes.config.font = "impact"
 memes.config.color = "white"
+memes.config.fontsize = 72.0
 memes.config.style = "upper"

--- a/examples/plot_customization.py
+++ b/examples/plot_customization.py
@@ -19,6 +19,17 @@ memes.meme(
 )
 
 # %%
+# Font Size
+# ----------
+#
+# Use ``fontsize`` to set the text size in points.
+
+memes.meme(
+    "buzz", "big text", "big memes",
+    fontsize=120, show=False,
+)
+
+# %%
 # Outline Control
 # ----------------
 #

--- a/src/memeplotlib/_config.py
+++ b/src/memeplotlib/_config.py
@@ -7,6 +7,7 @@ DEFAULT_FONT = "impact"
 DEFAULT_COLOR = "white"
 DEFAULT_OUTLINE_COLOR = "black"
 DEFAULT_OUTLINE_WIDTH = 2.0
+DEFAULT_FONTSIZE = 72.0
 DEFAULT_DPI = 150
 DEFAULT_STYLE = "upper"
 DEFAULT_FIGSIZE_WIDTH = 8.0
@@ -33,6 +34,8 @@ class MemeplotlibConfig:
         Default text outline color.
     outline_width : float
         Default outline stroke width.
+    fontsize : float
+        Base font size in points for auto-sizing.
     dpi : int
         Default dots per inch for rendering.
     style : str
@@ -54,6 +57,7 @@ class MemeplotlibConfig:
     color: str = DEFAULT_COLOR
     outline_color: str = DEFAULT_OUTLINE_COLOR
     outline_width: float = DEFAULT_OUTLINE_WIDTH
+    fontsize: float = DEFAULT_FONTSIZE
     dpi: int = DEFAULT_DPI
     style: str = DEFAULT_STYLE
     cache_enabled: bool = True

--- a/src/memeplotlib/_rendering.py
+++ b/src/memeplotlib/_rendering.py
@@ -261,7 +261,7 @@ def _draw_meme_text(
     display_text = _smart_wrap(display_text, pos.scale_x)
 
     if fontsize is None:
-        fontsize = _auto_fontsize(display_text, pos.scale_x, pos.scale_y)
+        fontsize = _auto_fontsize(display_text, pos.scale_x, pos.scale_y, base_size=config.fontsize)
 
     font_family = _resolve_font(font)
 

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -56,6 +56,32 @@ class TestAutoFontsize:
         assert wide > narrow
 
 
+class TestAutoFontsizeConfig:
+    def test_default_base_size_is_72(self):
+        from memeplotlib._config import DEFAULT_FONTSIZE
+        assert DEFAULT_FONTSIZE == 72.0
+
+    def test_config_fontsize_affects_auto_size(self):
+        from memeplotlib._config import config
+        original = config.fontsize
+        try:
+            config.fontsize = 100.0
+            large = _auto_fontsize("hello", 1.0, 0.2, base_size=config.fontsize)
+            config.fontsize = 50.0
+            small = _auto_fontsize("hello", 1.0, 0.2, base_size=config.fontsize)
+            assert large > small
+        finally:
+            config.fontsize = original
+
+    def test_explicit_fontsize_overrides_auto(self):
+        fig, ax = plt.subplots()
+        pos = TextPosition()
+        txt = _draw_meme_text(ax, "hello", 0.5, 0.9, pos, fontsize=24.0)
+        # The text object should start at the explicit size (may be shrunk by
+        # _fit_text_to_box, but never larger)
+        assert txt.get_fontsize() <= 24.0
+
+
 class TestSmartWrap:
     def test_short_text_no_wrap(self):
         assert _smart_wrap("hello", 1.0) == "hello"


### PR DESCRIPTION
## Summary
This PR adds a new `fontsize` configuration option to control the base font size used for automatic text sizing in memes. Previously, the auto-sizing algorithm used a hardcoded value of 72 points. Now users can customize this globally via `config.fontsize` or override it per-meme with the `fontsize` parameter.

## Key Changes
- Added `DEFAULT_FONTSIZE = 72.0` constant and `fontsize` field to `MemeplotlibConfig` class
- Modified `_draw_meme_text()` to pass `config.fontsize` as the `base_size` parameter to `_auto_fontsize()`
- Added comprehensive test coverage in `TestAutoFontsizeConfig` class:
  - Verify default base size is 72 points
  - Confirm config changes affect auto-sizing behavior
  - Ensure explicit `fontsize` parameter overrides auto-sizing
- Updated documentation in `tutorial.rst` and `user_guide.rst` with font size configuration examples
- Added example scripts demonstrating font size customization in `plot_customization.py` and `plot_configuration.py`
- Updated README with font size configuration example

## Implementation Details
- The `fontsize` parameter in `_draw_meme_text()` takes precedence when explicitly provided
- When `fontsize=None`, the auto-sizing algorithm uses `config.fontsize` as the base size
- The configuration is global and affects all subsequent meme creations until changed
- Default value of 72 points maintains backward compatibility with existing behavior

https://claude.ai/code/session_018wdJAAYwmxw4eMxrcYcxR5