### PR TITLE
Add workflow to automatically regenerate example images

### DIFF
--- a/.github/workflows/regenerate-examples.yml
+++ b/.github/workflows/regenerate-examples.yml
@@ -1,0 +1,49 @@
+name: Regenerate Example Images
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: regenerate-examples
+  cancel-in-progress: true
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Regenerate example images
+        run: python docs/generate_examples.py
+
+      - name: Check for changes
+        id: changes
+        run: |
+          git diff --quiet docs/_static/examples/ && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push updated images
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/_static/examples/
+          git commit -m "Regenerate example images for ${{ github.event.release.tag_name || 'manual run' }}"
+          git push origin main


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow that automatically regenerates example images when a release is published or manually triggered.

## Key Changes
- Added `.github/workflows/regenerate-examples.yml` workflow that:
  - Triggers on release publication or manual workflow dispatch
  - Sets up Python 3.10 environment and installs project dependencies
  - Runs the example generation script (`docs/generate_examples.py`)
  - Detects changes to generated example images
  - Automatically commits and pushes updated images to the main branch if changes are detected
  - Uses concurrency controls to prevent simultaneous runs

## Implementation Details
- The workflow uses the GitHub Actions bot account for commits to maintain clean git history
- Includes a change detection step to avoid unnecessary commits when no images have changed
- Configured with `cancel-in-progress: true` to ensure only the latest workflow run proceeds
- Checks out the `main` branch explicitly to ensure consistency

https://claude.ai/code/session_01HA9bpMGvGb3FySQxr6RjFe