### PR TITLE
Use GitHub release metadata for docs release string

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+import json
 
 # Make sure the source directory is importable for autodoc
 sys.path.insert(0, os.path.abspath("../src"))
@@ -14,7 +15,23 @@ sys.path.insert(0, os.path.abspath("../src"))
 project = "memeplotlib"
 copyright = "2025, Brian Keegan"
 author = "Brian Keegan"
-release = "0.1.0"
+
+
+def _get_release() -> str:
+    """Resolve the docs release string from GitHub release metadata when available."""
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if event_path and os.path.exists(event_path):
+        with open(event_path, encoding="utf-8") as event_file:
+            event_payload = json.load(event_file)
+
+        release_tag = event_payload.get("release", {}).get("tag_name")
+        if release_tag:
+            return release_tag
+
+    return os.environ.get("GITHUB_REF_NAME", "0.1.0")
+
+
+release = _get_release()
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
### Motivation
- Replace the hard-coded Sphinx `release` in `docs/conf.py` with the GitHub release/tag when docs are built from a release event, falling back to `GITHUB_REF_NAME` and then to `"0.1.0"`; no skills were used.

### Description
- Update `docs/conf.py` to import `json`, add a `_get_release()` helper that reads the GitHub event payload from `GITHUB_EVENT_PATH` and returns `release.tag_name` when available, otherwise returns `GITHUB_REF_NAME` or the default `"0.1.0"`, and set `release = _get_release()`.

### Testing
- Ran `python -m py_compile docs/conf.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e8e69691c83229464e8c6793cd776)